### PR TITLE
Proposed bugfix for 'images' path

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@
 
 Ever wanted to turn some text into a EPUB, but it seemed like too much of a hassle? This is the library for you.
 
+### Installation
+
+```
+pip3 install --user mkepub
+```
+
 ### Basic Usage
 
 ```python

--- a/mkepub/mkepub.py
+++ b/mkepub/mkepub.py
@@ -74,7 +74,7 @@ class Book:
     def add_image(self, name, data):
         """Add image file."""
         self.images.append(Image(next(self._image_id), name))
-        with open(str(self.path / 'images' / name), 'wb') as file:
+        with open(str(self.path / 'EPUB/images' / name), 'wb') as file:
             file.write(data)
 
     def set_cover(self, data):


### PR DESCRIPTION
'images' path needs to have 'EPUB' path prefix, otherwise adding images fails