### PR TITLE
add support for page anchors in TOC

### DIFF
--- a/mkepub/mkepub.py
+++ b/mkepub/mkepub.py
@@ -75,18 +75,26 @@ class Book:
         Add a new page.
 
         The page will be added as a subpage of the parent. If no parent is
-        provided, the page will be added to the root of the book.
+        provided, the page will be added to the root of the book. Additionally,
+        each page can provide a list of anchors which will be visible in the
+        TOC. The anchors take precedence over child pages in the TOC.
+        The anchors can be specified as a list of ids, a list of (id, title)
+        tuples or a dictionary where the keys are the anchor ids and the values
+        the anchor titles.
         """
         if anchors is None:
             anchors = []
 
-        def mk_anchor(value):
-            if isinstance(value, tuple) and len(value) == 2:
-                return Anchor(value[0], value[1])
+        if isinstance(anchors, dict):
+            anchors = anchors.items()
+        elif isinstance(anchors, list) and anchors:
+            if len(anchors[0]) == 1:
+                anchors = list(zip(anchors, anchors))
             else:
-                return Anchor(value, value)
+                anchors = [(element[0], element[1]) for element in anchors]
 
-        anchors = list(map(mk_anchor, anchors))
+        anchors = list(map(lambda item: Anchor(*item), anchors))
+
         page = Page(next(self._page_id), title, anchors, [])
         self.root.append(page) if not parent else parent.children.append(page)
         self._write_page(page, content)

--- a/mkepub/mkepub.py
+++ b/mkepub/mkepub.py
@@ -38,7 +38,8 @@ env.filters['mediatype'] = mediatype
 
 ###############################################################################
 
-Page = collections.namedtuple('Page', 'page_id title children')
+Anchor = collections.namedtuple('Anchor', 'anchor_id title')
+Page = collections.namedtuple('Page', 'page_id title anchors children')
 Image = collections.namedtuple('Image', 'image_id name')
 
 
@@ -69,14 +70,24 @@ class Book:
     # Public Methods
     ###########################################################################
 
-    def add_page(self, title, content, parent=None):
+    def add_page(self, title, content, anchors=None, parent=None):
         """
         Add a new page.
 
         The page will be added as a subpage of the parent. If no parent is
         provided, the page will be added to the root of the book.
         """
-        page = Page(next(self._page_id), title, [])
+        if anchors is None:
+            anchors = []
+
+        def mk_anchor(value):
+            if isinstance(value, tuple) and len(value) == 2:
+                return Anchor(value[0], value[1])
+            else:
+                return Anchor(value, value)
+
+        anchors = list(map(mk_anchor, anchors))
+        page = Page(next(self._page_id), title, anchors, [])
         self.root.append(page) if not parent else parent.children.append(page)
         self._write_page(page, content)
         return page

--- a/mkepub/mkepub.py
+++ b/mkepub/mkepub.py
@@ -70,7 +70,7 @@ class Book:
     # Public Methods
     ###########################################################################
 
-    def add_page(self, title, content, anchors=None, parent=None):
+    def add_page(self, title, content, parent=None, anchors=None):
         """
         Add a new page.
 

--- a/mkepub/mkepub.py
+++ b/mkepub/mkepub.py
@@ -78,20 +78,18 @@ class Book:
         provided, the page will be added to the root of the book. Additionally,
         each page can provide a list of anchors which will be visible in the
         TOC. The anchors take precedence over child pages in the TOC.
-        The anchors can be specified as a list of ids, a list of (id, title)
-        tuples or a dictionary where the keys are the anchor ids and the values
-        the anchor titles.
+        The anchors can be specified as a list of (id, title) tuples or a
+        dictionary id: title pairs.
         """
         if anchors is None:
             anchors = []
 
         if isinstance(anchors, dict):
-            anchors = anchors.items()
+            anchors = list(sorted(anchors.items()))
         elif isinstance(anchors, list) and anchors:
-            if len(anchors[0]) == 1:
-                anchors = list(zip(anchors, anchors))
-            else:
-                anchors = [(element[0], element[1]) for element in anchors]
+            anchors = [(element[0], element[1])
+                       for element in anchors
+                       if isinstance(element, tuple) and len(element) >= 2]
 
         anchors = list(map(lambda item: Anchor(*item), anchors))
 

--- a/mkepub/templates/toc.ncx
+++ b/mkepub/templates/toc.ncx
@@ -15,6 +15,14 @@
                 <text>{{ page.title }}</text>
             </navLabel>
             <content src="page{{ page.page_id }}.xhtml"/>
+            {%- for anchor in page.anchors %}
+            <navPoint id="id-{{ page.page_id }}-{{ anchor.anchor_id }}">
+                <navLabel>
+                    <text>{{ anchor.title }}</text>
+                </navLabel>
+                <content src="page{{ page.page_id }}.xhtml#{{ anchor.anchor_id }}"/>
+            </navPoint>
+            {%- endfor %}
             {%- if page.children %}
             {{ loop(page.children) }}
             {%- endif %}

--- a/mkepub/templates/toc.xhtml
+++ b/mkepub/templates/toc.xhtml
@@ -14,6 +14,13 @@
       {%- for page in pages recursive %}
         <li>
           <a href="page{{ page.page_id }}.xhtml">{{ page.title }}</a>
+          {%- if page.anchors %}
+          <ol>
+            {%- for anchor in page.anchors %}
+            <li><a href="page{{ page.page_id }}.xhtml#{{ anchor.anchor_id }}">{{ anchor.title }}</a></li>
+            {%- endfor %}
+          </ol>
+          {%- endif %}
           {%- if page.children %}
           <ol>{{ loop(page.children) }}</ol>
           {%- endif %}

--- a/mkepub/tests/test_mkepub.py
+++ b/mkepub/tests/test_mkepub.py
@@ -73,14 +73,18 @@ def test_book_nested():
 
 
 def test_book_with_anchors():
-    book = mkepub.Book('Anchors')
-    parent = book.add_page('Parent Page', '0000-0000')
-    book.add_page('First Child', '''
+    text = '''
     <h1 id="anchor-1">Anchor 1</h1> 
     <p> Text for anchor 1 </p>
     <h1 id="anchor-2">Anchor 2</h1>
     <p> Text for anchor 1 </p>
-    ''', parent, anchors=[('anchor-1', 'Anchor 1'), ('anchor-2', 'Anchor 2')])
+    '''
+    book = mkepub.Book('Anchors')
+    parent = book.add_page('Parent Page', '0000-0000')
+    book.add_page('First Child', text, parent,
+                  anchors=[('anchor-1', 'Anchor 1'), ('anchor-2', 'Anchor 2')])
+    book.add_page('Third Child', text, parent,
+                  anchors={'anchor-1': 'Anchor 1', 'anchor-2': 'Anchor 2'})
     save_and_check(book)
 
 

--- a/mkepub/tests/test_mkepub.py
+++ b/mkepub/tests/test_mkepub.py
@@ -72,6 +72,18 @@ def test_book_nested():
     save_and_check(book)
 
 
+def test_book_with_anchors():
+    book = mkepub.Book('Anchors')
+    parent = book.add_page('Parent Page', '0000-0000')
+    book.add_page('First Child', '''
+    <h1 id="anchor-1">Anchor 1</h1> 
+    <p> Text for anchor 1 </p>
+    <h1 id="anchor-2">Anchor 2</h1>
+    <p> Text for anchor 1 </p>
+    ''', parent, anchors=[('anchor-1', 'Anchor 1'), ('anchor-2', 'Anchor 2')])
+    save_and_check(book)
+
+
 def test_book_with_images():
     book = mkepub.Book('Images')
     book.add_page('Cover Page', '<img src="images/cover.jpg"></img>')


### PR DESCRIPTION
if specified, anchors appear in TOC. Anchor support is optional making the mkepub API backwards compatible. One downside is that it is the responsibility of the page writer to put the anchor `id` attributes in the proper places and collect them in the `anchors` argument.