### PR TITLE
Copy latest changes from README.md

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,6 +11,7 @@ mkepub
 -  Automatically generated TOC.
 -  Support for nested TOC of any depth.
 -  Support for embedded images.
+-  Support for embedded fonts.
 -  In-progress books are stored on disk rather than in memory, enabling
    creation of large (5000+ pages, 20+ MiBs) epub files.
 -  Adherence to the EPUB3 specs.
@@ -21,8 +22,6 @@ mkepub
 
 -  No support for custom page filenames or directory structure.
 -  No support for reading or editing epub files.
--  No support for font-embedding or most other less commonly used EPUB
-   features.
 -  No content validation - using broken or unsupported html code as page
    content will lead to mkepub successfully creating a .epub file that
    does not meet EPUB3 specifications.


### PR DESCRIPTION
Does it make sense to keep a README.rst and a README.md?

@anqxyr hi! I noticed that on the #4 the README.md was updated, but that file is not used on pypi, so there it still says that embbedding fonts is still not supported.

Would it be welcomed a pull request that just removes README.md? :thinking: or there is a reason to keep both a README.rst and a README.md?