### PR TITLE
Use `image/svg+xml` media-type for SVG files.

### DIFF
--- a/mkepub/mkepub.py
+++ b/mkepub/mkepub.py
@@ -30,6 +30,8 @@ def mediatype(name):
         raise ValueError('Image format "{}" is not supported.'.format(ext))
     if ext == 'jpg':
         ext = 'jpeg'
+    elif ext == 'svg':
+        ext = 'svg+xml'
     return 'image/' + ext
 
 

--- a/mkepub/tests/test_mkepub.py
+++ b/mkepub/tests/test_mkepub.py
@@ -104,3 +104,11 @@ def test_add_file():
     with open('mkepub/tests/cover.jpg', 'rb') as file:
         book._add_file('files/cover_1.jpg', file.read())
     assert (book.path / 'EPUB/files/cover_1.jpg').exists()
+
+
+def test_mediatype():
+    assert mkepub.mkepub.mediatype('file.png') == 'image/png'
+    assert mkepub.mkepub.mediatype('file.jpg') == 'image/jpeg'
+    assert mkepub.mkepub.mediatype('file.jpeg') == 'image/jpeg'
+    assert mkepub.mkepub.mediatype('file.gif') == 'image/gif'
+    assert mkepub.mkepub.mediatype('file.svg') == 'image/svg+xml'


### PR DESCRIPTION
The spec allows for `image/svg+xml` to be included without a fallback, but does not mention `image/svg`. This causes violations in epubcheck when mkepub inserts an SVG file.

https://www.w3.org/publishing/epub3/epub-spec.html#tbl-core-media-types