### PR TITLE
Exclude mkepub/tests/* from coverage.py

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,4 @@
 [report]
-omit = */templates/* 
+omit =
+    */templates/*
+    mkepub/tests/*

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-license_file = LICENSE 
+license_file = LICENSE


### PR DESCRIPTION
It doesn't make sense to measure the test coverage of the tests themselves, so exclude them from coverage.py.

This corrects some spurious Coveralls complaints in GitHub PRs.

Also remove some stray whitespace at the end of the license_file line.