### PR TITLE
Add dcterms to package.opf template

### DIFF
--- a/mkepub/templates/package.opf
+++ b/mkepub/templates/package.opf
@@ -8,6 +8,9 @@
     <dc:language>{{ lang if lang else 'en' }}</dc:language>
     <dc:date>{{ published if published else date[:10] }}</dc:date>
     <meta property="dcterms:modified">{{ date }}</meta>
+    {% if dcterms %}{%- for name, value in dcterms.items() %}
+    <meta property="dcterms:{{ name }}">{{ value }}</meta>
+    {%- endfor %}{% endif %}
     {%- if author %}
     <dc:creator>{{ author|escape }}</dc:creator>
     {%- endif %}

--- a/mkepub/tests/test_mkepub.py
+++ b/mkepub/tests/test_mkepub.py
@@ -6,6 +6,7 @@ import logging
 import mkepub
 import pathlib
 import pytest
+from zipfile import ZipFile
 
 ###############################################################################
 
@@ -15,8 +16,12 @@ logging.basicConfig(
 logger.setLevel(logging.WARNING)
 
 
+def name_for_book(book):
+    return 'mkepub/tests/{}.epub'.format(book.title.lower().replace(' ', '_'))
+
+
 def save_and_check(book):
-    name = 'mkepub/tests/{}.epub'.format(book.title.lower().replace(' ', '_'))
+    name = name_for_book(book)
     path = pathlib.Path(name)
     if path.exists():
         path.unlink()
@@ -25,6 +30,14 @@ def save_and_check(book):
     for m in r.messages:
         logger.warning('{0.level} {0.location}: {0.message}'.format(m))
     assert r.valid
+
+
+def assert_has_contents(book, file, expected_strings):
+    name = name_for_book(book)
+    zipfile = ZipFile(name, 'r')
+    contents = zipfile.read(file)
+    for expected_string in expected_strings:
+        assert bytes(expected_string, 'utf-8') in contents
 
 ###############################################################################
 
@@ -104,3 +117,15 @@ def test_add_file():
     with open('mkepub/tests/cover.jpg', 'rb') as file:
         book._add_file('files/cover_1.jpg', file.read())
     assert (book.path / 'EPUB/files/cover_1.jpg').exists()
+
+
+def test_book_with_dcterms():
+    book = mkepub.Book('DCTerms', dcterms={'available': '5', 'audience': 'everyone'})
+    book.add_page('Page 1', 'Content')
+    save_and_check(book)
+
+    expected_strings = [
+        '<meta property="dcterms:available">5</meta>\n',
+        '<meta property="dcterms:audience">everyone</meta>\n'
+    ]
+    assert_has_contents(book, 'EPUB/package.opf', expected_strings)


### PR DESCRIPTION
The EPUB spec allows for Dublin Core metadata terms. This commit adds support for them to the package.opf template.

No API change is necessary—all metadata is already passed through to the template.

It is the client's responsibility to ensure that only valid DC terms are supplied (just as page content HTML).

https://www.w3.org/publishing/epub3/epub-packages.html#sec-metadata-reserved-prefixes
https://www.dublincore.org/specifications/dublin-core/dcmi-terms/