### PR TITLE
add MANIFEST.in to workaround pip install failure when building a wheel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,7 @@ __pycache__/
 *mkepub/tests/test.log
 build/
 dist/
+venv/
 .coverage
 .cache
+.eggs/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,8 @@
+include LICENSE
+include README.rst
+include include *.md
+include setup.py
+recursive-include mkepub *.py
+graft mkpub/template
+graft mkpub/tests
+global-exclude *.py[cod]

--- a/mkepub/mkepub.py
+++ b/mkepub/mkepub.py
@@ -11,20 +11,29 @@ creating epub files, by sacrificing most of the versatility of the format.
 # Module Imports
 ###############################################################################
 
+# Python standard modules
 import collections
 import datetime
-import imghdr
 import itertools
-import jinja2
 import pathlib
 import tempfile
 import uuid
 import zipfile
 
+# third-party dependencies
+import jinja2
+
+# PEP 594 proposes deprecation of `imghdr` in Python 3.11
+# https://peps.python.org/pep-0594/#imghdr
+# a suggested replacement is `filetype`
+#import imghdr
+import filetype
+
 
 ###############################################################################
 
 def mediatype(name):
+    # NB: some of this could be replaced by `filetype.guess_mime()`
     ext = name.split('.')[-1].lower()
     if ext not in ('png', 'jpg', 'jpeg', 'gif', 'svg'):
         raise ValueError('Image format "{}" is not supported.'.format(ext))
@@ -110,7 +119,11 @@ class Book:
 
     def set_cover(self, data):
         """Set the cover image to the given data."""
-        self._cover = 'cover.' + imghdr.what(None, h=data)
+        # workaround for PEP 594 deprecation of `imghdr`
+        #extension = imghdr.what(None, h=data)
+        extension = filetype.guess_extension(data)
+
+        self._cover = 'cover.' + extension
         self._add_file(pathlib.Path('covers') / self._cover, data)
         self._write('cover.xhtml', 'EPUB/cover.xhtml', cover=self._cover)
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.rst') as f:
 
 setuptools.setup(
     name='mkepub',
-    version='1.2',
+    version='1.3',
     description='Simple minimalistic library for creating EPUB3 files',
     long_description=readme,
     url='https://github.com/anqxyr/mkepub/',
@@ -23,5 +23,5 @@ setuptools.setup(
     packages=['mkepub'],
     package_data={'mkepub': ['templates/*']},
     tests_require=['epubcheck', 'pytest', 'pytest-cov', 'python-coveralls'],
-    install_requires=['jinja2'],
+    install_requires=['filetype', 'jinja2'],
 )


### PR DESCRIPTION
This PR is a proposed fix to #19 

  * adds a `MANIFEST.in` file to workaround the `pip` failure when building a wheel
  * replaces `imghr` with the suggested `filetype`

[PEP 594](https://peps.python.org/pep-0594/#imghdr) proposes deprecation of `imghdr` in Python 3.11 and suggests using `filetype` as a replacement.

This was tested with the `pytest` unit tests, and also has the version bumped already to v1.3 (though it might need to be a minor release instead?)